### PR TITLE
fix: don't evaluate code sending API calls in vignettes

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: hackeRnews
 Title: Wrapper for the 'Official Hacker News' API
-Version: 0.2.1.9000
+Version: 0.2.2
 Authors@R: c(
     person(given = "Ryszard",
            family = "Szymanski",

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -25,7 +25,7 @@ Suggests:
     spelling,
     tibble
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.3.2
+RoxygenNote: 7.3.3
 Imports: 
     utils,
     httr2

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,9 @@
 # hackeRnews (development version)
 
+# hackeRnews 0.2.2
+
+* Update vignettes to not evaluate code chunks that make API requests.
+
 # hackeRnews 0.2.1
 
 * Provided direct imports in NAMESPACE.

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,7 +2,7 @@
 
 # hackeRnews 0.2.2
 
-* Update vignettes to not evaluate code chunks that make API requests.
+* Updated vignettes to not evaluate code chunks that make API requests.
 
 # hackeRnews 0.2.1
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,3 @@
-# hackeRnews (development version)
-
 # hackeRnews 0.2.2
 
 * Updated vignettes to not evaluate code chunks that make API requests.

--- a/cran-comments.md
+++ b/cran-comments.md
@@ -1,0 +1,3 @@
+Patch release to address issues reported by CRAN.
+
+* R CMD check errors when building vignettes caused by an unavailable Internet resource

--- a/vignettes/hackeRnews-specs.Rmd
+++ b/vignettes/hackeRnews-specs.Rmd
@@ -39,16 +39,16 @@ To fetch best/new/top stories the user can use the `get_*_stories` function. Eac
 
 For example to fetch the top 5 best stories:
 
-```{r}
+```{r, eval=FALSE}
 best_stories <- get_best_stories(max_items = 5)
 best_stories[[1]]
 ```
 
 There is a method that allows to fetch just raw ids of best/new/top stories as well `get_*_stories_ids()`
 
-```{r}
+```{r, eval=FALSE}
 best_stories_ids <- get_best_stories_ids()
-best_stories_ids[1:5] # output truncated for legibility
+best_stories_ids
 ```
 
 ### ask / job / show stories
@@ -57,7 +57,7 @@ Similar to news stories. There are `get_latest_*_stories` that returns latest * 
 
 For example to fetch the 3 latest ask stories:
 
-```{r}
+```{r, eval=FALSE}
 ask_stories <- get_latest_ask_stories(max_items = 3)
 ask_stories[[1]]
 ```
@@ -66,7 +66,7 @@ ask_stories[[1]]
 ### comments
 The discussion in story threads is represented as system of comments. Each story has top level comments ids stored under the `kids` property. Each comment post can have it's own set of comments ids under `kids` property (sub-comments) and so on. In order to retrieve all of the comments of a specific story, just use the `get_comments` function.
 
-```{r}
+```{r, eval=FALSE}
 top_story <- get_top_stories(max_items = 1)[[1]]
 get_comments(top_story)
 ```
@@ -75,7 +75,7 @@ get_comments(top_story)
 
 To fetch data about user 'jl' just use the `get_user_by_username` function:
 
-```{r}
+```{r, eval=FALSE}
 user <- get_user_by_username("jl")
 user
 ```
@@ -95,8 +95,8 @@ latest_items <- get_items_by_ids(seq(max_item_id, max_item_id - 10))
 
 Latest items and profile changes can be retrieved using `get_updates`
 
-```{r}
+```{r, eval=FALSE}
 updates <- get_updates()
-updates$profiles[1:5] # output truncated for legibility
-updates$items[1:5]    # output truncated for legibility
+updates$profiles
+updates$items
 ```


### PR DESCRIPTION
In case of resources being available, this will lead to errors when regenerating the vignette

Handling errors in the vignette would make the docs more cluttered, so not evaluating code seems like the better option